### PR TITLE
feat: add support for select, offset, startAt, startAfter, endAt, end…

### DIFF
--- a/lib/firebase_admin_interop.dart
+++ b/lib/firebase_admin_interop.dart
@@ -46,6 +46,6 @@ library firebase_admin_interop;
 export 'src/admin.dart';
 export 'src/app.dart';
 export 'src/auth.dart';
-export 'src/bindings.dart' show AppOptions;
+export 'src/bindings.dart' show AppOptions, FieldValue;
 export 'src/database.dart';
 export 'src/firestore.dart';

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -217,6 +217,9 @@ void main() {
       test('delete field', () async {
         var ref = app.firestore().document('tests/delete_field');
 
+        // Make sure FieldValue class is exported by using it here
+        FieldValue fieldValueDelete = Firestore.fieldValues.delete();
+
         // create document
         var documentData = new DocumentData();
         documentData.setString("some_key", "some_value");
@@ -229,7 +232,7 @@ void main() {
 
         // delete field
         var updateData = new UpdateData();
-        updateData.setFieldValue("some_key", Firestore.fieldValues.delete());
+        updateData.setFieldValue("some_key", fieldValueDelete);
         await ref.updateData(updateData);
 
         // read again

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -63,22 +63,44 @@ void main() {
         expect(nested.getString('author'), 'Isaac Asimov');
       });
 
+      // test setter and getters and fromMap/toMap round trip for
+      // all types
       test('get set', () {
         var data = new DocumentData();
         DateTime now = new DateTime.now();
-        data.setFieldValue('fieldValue', FieldValue.serverTimestamp);
         data.setInt('intVal', 1);
         data.setDouble('doubleVal', 1.5);
         data.setBool('boolVal', true);
         data.setString('stringVal', 'text');
         data.setDateTime('dateVal', now);
+        data.setGeoPoint('geoVal', new GeoPoint(23.03, 19.84));
+        data.setReference('refVal', app.firestore().document('users/23'));
+        data.setList('listVal', [23, 84]);
+        var nestedData = new DocumentData();
+        nestedData.setString('nestedVal', 'very nested');
+        data.setNestedData('nestedData', nestedData);
+        data.setFieldValue(
+            'serverTimestampFieldValue', FieldValue.serverTimestamp);
+        data.setFieldValue('deleteFieldValue', FieldValue.delete);
 
         _check() {
+          expect(data.keys.length, 11);
           expect(data.getInt('intVal'), 1);
           expect(data.getDouble('doubleVal'), 1.5);
+          expect(data.getBool('boolVal'), true);
           expect(data.getString('stringVal'), 'text');
           expect(data.getDateTime('dateVal'), now);
-          expect(data.getFieldValue('fieldValue'), FieldValue.serverTimestamp);
+          expect(data.getGeoPoint('geoVal'), new GeoPoint(23.03, 19.84));
+          var documentReference = data.getReference('refVal');
+          expect(documentReference.path, 'users/23');
+          expect(data.getList('listVal'), [23, 84]);
+          DocumentData nestedData = data.getNestedData('nestedData');
+          expect(nestedData.keys.length, 1);
+          expect(nestedData.getString('nestedVal'), 'very nested');
+          // Check the field value (no getter here)
+          Map<String, dynamic> map = data.toMap();
+          expect(map['serverTimestampFieldValue'], FieldValue.serverTimestamp);
+          expect(map['deleteFieldValue'], FieldValue.delete);
         }
 
         _check();


### PR DESCRIPTION
…Before, FieldValue.delete, FieldValue.timestamp

select: all selecting fields. varargs needed here so original binding does not work
offset: was simply missing
startAt, startAfter, endAt, endBefore: copy what is done in firebase-dart (web)
FieldValue.timestamp and FieldValue.delete: add support for it

add unit tests