### PR TITLE
feat: add Blob support

### DIFF
--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -648,7 +648,7 @@ class Blob {
   List<int> get data => _data;
 
   Blob.fromUint8List(this._data);
-  Uint8List toUint8List() => _data;
+  Uint8List asUint8List() => _data;
 }
 
 /// A QuerySnapshot contains zero or more DocumentSnapshot objects.

--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -643,8 +643,12 @@ class GeoPoint {
 /// An immutable object representing an array of bytes.
 class Blob {
   final Uint8List _data;
+
   Blob(List<int> data) : _data = new Uint8List.fromList(data);
   List<int> get data => _data;
+
+  Blob.fromUint8List(this._data);
+  Uint8List toUint8List() => _data;
 }
 
 /// A QuerySnapshot contains zero or more DocumentSnapshot objects.

--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -374,7 +374,7 @@ class _FirestoreData {
     var value = getProperty(nativeInstance, key);
     if (value == null) return null;
     assert(_isBlob(value), 'Invalid value provided to $runtimeType.getBlob().');
-    return new Blob(new Uint8List.fromList(value));
+    return new Blob(value);
   }
 
   void setGeoPoint(String key, GeoPoint value) {
@@ -642,9 +642,9 @@ class GeoPoint {
 
 /// An immutable object representing an array of bytes.
 class Blob {
-  Blob(this.data);
-
-  Uint8List data;
+  final Uint8List _data;
+  Blob(List<int> data) : _data = new Uint8List.fromList(data);
+  List<int> get data => _data;
 }
 
 /// A QuerySnapshot contains zero or more DocumentSnapshot objects.

--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -373,9 +373,6 @@ class _FirestoreData {
   Blob getBlob(String key) {
     var value = getProperty(nativeInstance, key);
     if (value == null) return null;
-    //print('blob ${hasProperty(value, , name)objectKeys(value)}');
-    // value is a JsArray
-
     assert(_isBlob(value), 'Invalid value provided to $runtimeType.getBlob().');
     return new Blob(new Uint8List.fromList(value));
   }

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -75,7 +75,7 @@ void main() {
         data.setString('stringVal', 'text');
         data.setDateTime('dateVal', now);
         data.setGeoPoint('geoVal', new GeoPoint(23.03, 19.84));
-        data.setBlob('blob', new Blob(new Uint8List.fromList([1, 2, 3])));
+        data.setBlob('blob', new Blob([1, 2, 3]));
         data.setReference('refVal', app.firestore().document('users/23'));
         data.setList('listVal', [23, 84]);
         var nestedData = new DocumentData();
@@ -123,7 +123,7 @@ void main() {
           'doubleVal': 19.84,
           'dateVal': date,
           'geoVal': new GeoPoint(23.03, 19.84),
-          'blobVal': new Blob(new Uint8List.fromList([1, 2, 3])),
+          'blobVal': new Blob([1, 2, 3]),
           'refVal': app.firestore().document('users/23'),
           'listVal': [23, 84],
           'nestedVal': {'nestedKey': 'much nested'},
@@ -160,7 +160,7 @@ void main() {
           'dateVal': date,
           'geoVal': new GeoPoint(23.03, 19.84),
           'refVal': app.firestore().document('users/23'),
-          'blobVal': new Blob(new Uint8List.fromList([4, 5, 6])),
+          'blobVal': new Blob([4, 5, 6]),
           'listVal': [23, 84]
         });
         var nested = new DocumentData.fromMap({'nestedVal': 'very nested'});

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -2,6 +2,7 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 @TestOn('node')
 import 'package:firebase_admin_interop/firebase_admin_interop.dart';
@@ -74,6 +75,7 @@ void main() {
         data.setString('stringVal', 'text');
         data.setDateTime('dateVal', now);
         data.setGeoPoint('geoVal', new GeoPoint(23.03, 19.84));
+        data.setBlob('blob', new Blob(new Uint8List.fromList([1, 2, 3])));
         data.setReference('refVal', app.firestore().document('users/23'));
         data.setList('listVal', [23, 84]);
         var nestedData = new DocumentData();
@@ -84,13 +86,14 @@ void main() {
         data.setFieldValue('deleteFieldValue', Firestore.fieldValues.delete());
 
         _check() {
-          expect(data.keys.length, 11);
+          expect(data.keys.length, 12);
           expect(data.getInt('intVal'), 1);
           expect(data.getDouble('doubleVal'), 1.5);
           expect(data.getBool('boolVal'), true);
           expect(data.getString('stringVal'), 'text');
           expect(data.getDateTime('dateVal'), now);
           expect(data.getGeoPoint('geoVal'), new GeoPoint(23.03, 19.84));
+          expect(data.getBlob('blob').data, [1, 2, 3]);
           var documentReference = data.getReference('refVal');
           expect(documentReference.path, 'users/23');
           expect(data.getList('listVal'), [23, 84]);
@@ -120,6 +123,7 @@ void main() {
           'doubleVal': 19.84,
           'dateVal': date,
           'geoVal': new GeoPoint(23.03, 19.84),
+          'blobVal': new Blob(new Uint8List.fromList([1, 2, 3])),
           'refVal': app.firestore().document('users/23'),
           'listVal': [23, 84],
           'nestedVal': {'nestedKey': 'much nested'},
@@ -135,6 +139,7 @@ void main() {
         expect(result.getDouble('doubleVal'), 19.84);
         expect(result.getDateTime('dateVal'), date);
         expect(result.getGeoPoint('geoVal'), new GeoPoint(23.03, 19.84));
+        expect(result.getBlob('blobVal').data, [1, 2, 3]);
         var docRef = result.getReference('refVal');
         expect(docRef, new isInstanceOf<DocumentReference>());
         expect(docRef.path, 'users/23');
@@ -146,7 +151,7 @@ void main() {
 
       test('$DocumentData.toMap', () async {
         var date = new DateTime.now();
-        var ref = app.firestore().document('tests/data-types');
+        var ref = app.firestore().document('tests/data-types-toMap');
         var data = new DocumentData.fromMap({
           'boolVal': true,
           'stringVal': 'text',
@@ -155,6 +160,7 @@ void main() {
           'dateVal': date,
           'geoVal': new GeoPoint(23.03, 19.84),
           'refVal': app.firestore().document('users/23'),
+          'blobVal': new Blob(new Uint8List.fromList([4, 5, 6])),
           'listVal': [23, 84]
         });
         var nested = new DocumentData.fromMap({'nestedVal': 'very nested'});
@@ -178,6 +184,7 @@ void main() {
         expect(result['doubleVal'], 19.84);
         expect(result['dateVal'], date);
         expect(result['geoVal'], new GeoPoint(23.03, 19.84));
+        expect((result['blobVal'] as Blob).data, [4, 5, 6]);
         var docRef = result['refVal'];
         expect(docRef, new isInstanceOf<DocumentReference>());
         expect(docRef.path, 'users/23');


### PR DESCRIPTION
Although the node API does not clearly specify a type for Blob (but this type is present in the web implementation https://firebase.google.com/docs/reference/js/firebase.firestore.Blob), there was no easy way to get a binary content, add a convenient Blob class to hold the binary data