### PR TITLE
feat: add support for getCollections (root and document) and add id/path support to CollectionReference

### DIFF
--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -104,6 +104,14 @@ class Firestore {
         nativeInstance.runTransaction(allowInterop(jsUpdateFunction)));
   }
 
+  /// Fetches the root collections that are associated with this Firestore
+  /// database.
+  Future<List<CollectionReference>> getCollections() async =>
+      (await promiseToFuture<List>(nativeInstance.getCollections()))
+          .map((nativeCollectionReference) =>
+              CollectionReference(nativeCollectionReference, this))
+          .toList(growable: false);
+
   /// Creates a write batch, used for performing multiple writes as a single
   /// atomic operation.
   WriteBatch batch() => new WriteBatch(nativeInstance.batch());
@@ -151,6 +159,13 @@ class CollectionReference extends DocumentQuery {
     return promiseToFuture(nativeInstance.add(data.nativeInstance))
         .then((jsRef) => new DocumentReference(jsRef, firestore));
   }
+
+  /// The last path element of the referenced collection.
+  String get id => nativeInstance.id;
+
+  /// A string representing the path of the referenced collection (relative to
+  /// the root of the database).
+  String get path => nativeInstance.path;
 }
 
 /// A [DocumentReference] refers to a document location in a Firestore database
@@ -233,6 +248,13 @@ class DocumentReference {
     );
     return controller.stream;
   }
+
+  /// Fetches the subcollections that are direct children of this document.
+  Future<List<CollectionReference>> getCollections() async =>
+      (await promiseToFuture<List>(nativeInstance.getCollections()))
+          .map((nativeCollectionReference) =>
+              CollectionReference(nativeCollectionReference, firestore))
+          .toList(growable: false);
 }
 
 /// An enumeration of document change types.

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -283,10 +283,37 @@ void main() {
         readData = (await ref.get()).data;
         expect(readData.toMap(), {'value2': 4});
       });
+
+      test('getCollections', () async {
+        var doc = app.firestore().document('tests/get_collections');
+        // Create an element in a sub collection to make sure the collection
+        // exists
+        await doc
+            .collection('sub')
+            .document('item')
+            .setData(DocumentData.fromMap({}));
+        var collections = await doc.getCollections();
+        // Find our collection
+        bool found = false;
+        collections.forEach((CollectionReference col) {
+          if (col.id == 'sub') {
+            found = true;
+          }
+        });
+        expect(found, isTrue);
+      });
     });
 
     group('$CollectionReference', () {
       var ref = app.firestore().collection('users');
+
+      test('id and path', () {
+        expect(ref.id, 'users');
+        expect(ref.path, 'users');
+        var col = ref.document('sub').collection('item');
+        expect(col.id, 'item');
+        expect(col.path, 'users/sub/item');
+      });
 
       test('parent of root collection', () {
         final parent = ref.parent;
@@ -322,6 +349,20 @@ void main() {
         final doc = ref.document('abc');
         expect(doc.documentID, 'abc');
         expect(doc.path, 'users/abc');
+      });
+
+      test('getCollections', () async {
+        // create a document to make sure the collection is created
+        await ref.document('any').setData(DocumentData.fromMap({}));
+        var collections = await app.firestore().getCollections();
+        // Find our collection
+        bool found = false;
+        collections.forEach((CollectionReference col) {
+          if (col.path == ref.path) {
+            found = true;
+          }
+        });
+        expect(found, isTrue);
       });
     });
 


### PR DESCRIPTION
I needed getCollections support in my backend.

While testing it, I was missing the obvious path and id from a CollectionReference that I added as well