### PR TITLE
feat: add Firestore.getAll() support

### DIFF
--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -115,6 +115,18 @@ class Firestore {
   /// Creates a write batch, used for performing multiple writes as a single
   /// atomic operation.
   WriteBatch batch() => new WriteBatch(nativeInstance.batch());
+
+  /// Retrieves multiple documents from Firestore.
+  Future<List<DocumentSnapshot>> getAll(List<DocumentReference> refs) async {
+    return (await promiseToFuture<List>(callMethod(
+            nativeInstance,
+            'getAll',
+            refs
+                .map((DocumentReference ref) => ref.nativeInstance)
+                .toList(growable: false))))
+        .map((nativeSnapshot) => DocumentSnapshot(nativeSnapshot, this))
+        .toList(growable: false);
+  }
 }
 
 /// A CollectionReference object can be used for adding documents, getting

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -302,6 +302,25 @@ void main() {
         });
         expect(found, isTrue);
       });
+
+      test('getAll', () async {
+        // Create two records and try to read 3 (i.e. one missing)
+        var doc1 = app.firestore().document('tests/get_all_1');
+        var doc2 = app.firestore().document('tests/get_all_2');
+        var docDummy = app.firestore().document('tests/get_all_dummy');
+        await doc1.setData(DocumentData.fromMap({'value': 1}));
+        await doc2.setData(DocumentData.fromMap({'value': 2}));
+        var snapshots = await app.firestore().getAll([doc1, doc2, docDummy]);
+        expect(snapshots, hasLength(3));
+        expect(snapshots[0].reference.path, doc1.path);
+        expect(snapshots[0].exists, isTrue);
+        expect(snapshots[0].data.toMap(), {'value': 1});
+        expect(snapshots[1].reference.path, doc2.path);
+        expect(snapshots[1].exists, isTrue);
+        expect(snapshots[1].data.toMap(), {'value': 2});
+        expect(snapshots[2].reference.path, docDummy.path);
+        expect(snapshots[2].exists, isFalse);
+      });
     });
 
     group('$CollectionReference', () {


### PR DESCRIPTION
This is actually the most efficient way to read multiple records. Sorry I missed that in my latest pull request