### PR TITLE
fix: DocumentRef.update to support nested objects

### DIFF
--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -410,6 +410,9 @@ class _FirestoreData {
       setTimestamp(key, value);
     } else if (value is FieldValue) {
       setFieldValue(key, value);
+    } else if (value is Map) {
+      setNestedData(
+          key, new DocumentData.fromMap(value.cast<String, dynamic>()));
     } else {
       throw new ArgumentError.value(
           value, key, 'Unsupported value type for Firestore.');
@@ -728,16 +731,6 @@ class DocumentData extends _FirestoreData {
     return doc;
   }
 
-  @override
-  void _setField(String key, value) {
-    if (value is Map) {
-      setNestedData(
-          key, new DocumentData.fromMap(value.cast<String, dynamic>()));
-    } else {
-      super._setField(key, value);
-    }
-  }
-
   DocumentData getNestedData(String key) {
     final data = getProperty(nativeInstance, key);
     if (data == null) return null;
@@ -790,6 +783,7 @@ class UpdateData extends _FirestoreData {
 class Timestamp {
   final int seconds;
   final int nanoseconds;
+
   Timestamp(this.seconds, this.nanoseconds);
 
   factory Timestamp.fromDateTime(DateTime dateTime) {
@@ -1254,6 +1248,7 @@ abstract class _FieldValueArray implements FieldValue {
 
 class _FieldValueArrayUnion extends _FieldValueArray {
   _FieldValueArrayUnion(List elements) : super(elements);
+
   @override
   _jsify() {
     return callMethod(js.admin.firestore.FieldValue, 'arrayUnion',
@@ -1266,6 +1261,7 @@ class _FieldValueArrayUnion extends _FieldValueArray {
 
 class _FieldValueArrayRemove extends _FieldValueArray {
   _FieldValueArrayRemove(List elements) : super(elements);
+
   @override
   _jsify() {
     return callMethod(js.admin.firestore.FieldValue, 'arrayRemove',

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -376,6 +376,26 @@ void main() {
         expect(readData.toMap(), {'value2': 4});
       });
 
+      test('update sub fields', () async {
+        var ref = app.firestore().document('tests/set_options');
+        await ref.setData(DocumentData.fromMap({'created': 1, 'modified': 2}));
+        await ref.updateData(UpdateData.fromMap({
+          'modified': 22,
+          'added': 3,
+          // update allow specifying sub field using dot
+          'sub.field': 4,
+          // but also supports regular map
+          'other_sub': {'field': 5}
+        }));
+        expect((await ref.get()).data.toMap(), {
+          'created': 1,
+          'modified': 22,
+          'added': 3,
+          'sub': {'field': 4},
+          'other_sub': {'field': 5}
+        });
+      });
+
       test('getCollections', () async {
         var doc = app.firestore().document('tests/get_collections');
         // Create an element in a sub collection to make sure the collection


### PR DESCRIPTION
Firestore does support updating subfield using dot ('sub_object.field': 1) or using a regular map 'sub_object':{'field': 1}. The later was not working (only working for setData but not updateData so far)