### PR TITLE
fix: Use the correct jsify function in startAt/startAfter/endAt/endAfter

### DIFF
--- a/lib/src/firestore.dart
+++ b/lib/src/firestore.dart
@@ -1063,7 +1063,7 @@ class DocumentQuery {
     }
     List<dynamic> args = (snapshot != null)
         ? [snapshot.nativeInstance]
-        : values.map(jsify).toList();
+        : values.map(_FirestoreData._jsify).toList();
     return callMethod(nativeInstance, method, args);
   }
 

--- a/test/firestore_test.dart
+++ b/test/firestore_test.dart
@@ -555,6 +555,14 @@ void main() {
         expect(snapshot.documents, hasLength(1));
         var doc = snapshot.documents.single;
         expect(doc.documentID, doc1.documentID);
+
+        // Test with startAfter
+        query = collection.orderBy('createdAt').startAfter(values: [now]);
+        snapshot = await query.get();
+        expect(snapshot, isNotEmpty);
+        expect(snapshot.documents, hasLength(1));
+        doc = snapshot.documents.single;
+        expect(doc.documentID, doc2.documentID);
       });
 
       test('query filter with date', () async {
@@ -575,6 +583,14 @@ void main() {
         expect(snapshot.documents, hasLength(1));
         var doc = snapshot.documents.single;
         expect(doc.documentID, doc1.documentID);
+
+        // Test with startAfter
+        query = collection.orderBy('createdAt').startAfter(values: [now]);
+        snapshot = await query.get();
+        expect(snapshot, isNotEmpty);
+        expect(snapshot.documents, hasLength(1));
+        doc = snapshot.documents.single;
+        expect(doc.documentID, doc2.documentID);
       });
 
       test('query filter with geo point', () async {


### PR DESCRIPTION
fix: Use the correct jsify function in startAt/startAfter/endAt/endAfter to support DateTime and Timestamp

Add unit test that is failing without this change

I guess I missed this case in my previous change