### PR TITLE
Fixed Auth.setCustomUserClaims type

### DIFF
--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -106,7 +106,7 @@ class Auth {
   /// is transmitted on every authenticated request. For profile non-access
   /// related user attributes, use database or other separate storage systems.
   Future<void> setCustomUserClaims(
-          String uid, Map<String, String> customUserClaims) =>
+          String uid, Map<String, dynamic> customUserClaims) =>
       promiseToFuture(
           nativeInstance.setCustomUserClaims(uid, jsify(customUserClaims)));
 


### PR DESCRIPTION
Changed `Auth.setCustomUserClaims` from `Map<String, String>` to `Map<String, dynamic>` since that is what the official SDK uses and should not break anything since `jsify` expects a `dynamic` anyway.

See issue #55 