### PR TITLE
Added support for Firebase Messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.1.0
+
+Upgraded to support firebase-admin Messaging features to send cloud message payloads to device, topic, all, multicast, and subscribe/unsubscribe from topic.
+```dart
+  NotificationMessagePayload notification = NotificationMessagePayload(
+    title: title,
+    body: body,
+    clickAction: "event-" + event.documentID,
+
+  );
+  MessagingPayload payload = new MessagingPayload(notification: notification);
+  MessagingDevicesResponse result = await firestoreApp.messaging().sendToDevice(token, payload);
+  // or firestoreApp.messaging().sendToTopic(topic, payload);
+```
+- Breaking change: Updated versions of many dependancies in pubspec
+
 ## 2.0.0
 
 Upgraded to support firebase-admin Node.js SDK 8.0.0 or greater and `@google-cloud/firestore` 2.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ Upgraded to support firebase-admin Messaging features to send cloud message payl
   NotificationMessagePayload notification = NotificationMessagePayload(
     title: title,
     body: body,
-    clickAction: "event-" + event.documentID,
-
+    clickAction: "FLUTTER_NOTIFICATION_CLICK",
   );
-  MessagingPayload payload = new MessagingPayload(notification: notification);
+  MessagingPayload payload = new MessagingPayload(notification: notification, data: DataMessagePayload(data: {"doc" : event.reference.path}));
   MessagingDevicesResponse result = await firestoreApp.messaging().sendToDevice(token, payload);
   // or firestoreApp.messaging().sendToTopic(topic, payload);
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Current implementation coverage report:
 - [x] admin.credential
 - [x] admin.database
 - [x] admin.firestore
-- [ ] admin.messaging
+- [x] admin.messaging
 - [ ] admin.storage
 
 ## Features and bugs

--- a/lib/firebase_admin_interop.dart
+++ b/lib/firebase_admin_interop.dart
@@ -49,3 +49,4 @@ export 'src/auth.dart';
 export 'src/bindings.dart' show AppOptions, SetOptions, FirestoreSettings;
 export 'src/database.dart';
 export 'src/firestore.dart';
+export 'src/messaging.dart';

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -11,6 +11,7 @@ import 'auth.dart';
 import 'bindings.dart' as js;
 import 'database.dart';
 import 'firestore.dart';
+import 'messaging.dart';
 
 /// Represents initialized Firebase application and provides access to the
 /// app's services.
@@ -40,6 +41,11 @@ class App {
   Firestore firestore() =>
       _firestore ??= new Firestore(nativeInstance.firestore());
   Firestore _firestore;
+  
+  /// Gets [Messaging] client for this application.
+  Messaging messaging() =>
+      _messaging ??= new Messaging(nativeInstance.messaging());
+  Messaging _messaging;
 
   /// Renders this app unusable and frees the resources of all associated
   /// services.

--- a/lib/src/bindings.dart
+++ b/lib/src/bindings.dart
@@ -48,6 +48,9 @@ abstract class FirebaseAdmin {
   external FirestoreService get firestore;
 
   external Credentials get credential;
+  
+  /// Gets the [Messaging] service for the default app or a given [app].
+  external Messaging messaging([App app]);
 }
 
 @JS()
@@ -156,6 +159,9 @@ abstract class App {
 
   /// Gets the [Firestore] client for this app.
   external Firestore firestore();
+  
+  /// Gets the [Messaging] service for this app.
+  external Messaging messaging();
 }
 
 /// Available options to pass to [initializeApp].
@@ -534,6 +540,1165 @@ abstract class FirestoreService {
   external FieldValues get FieldValue;
   external dynamic get Timestamp;
   external dynamic get FieldPath;
+}
+
+// admin.messaging ================================================================
+
+/// The Firebase Messaging service interface.
+@JS()
+@anonymous
+abstract class Messaging {
+  /// The app associated with this Messaging service instance.
+  external App get app;
+
+  /// Sends the given message via FCM.
+  /// 
+  /// Returns Promise<string> fulfilled with a unique message ID string after the 
+  /// message has been successfully handed off to the FCM service for delivery
+  external Promise send(Message message, [bool dryRun]);
+
+  /// Sends all the messages in the given array via Firebase Cloud Messaging.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  external Promise sendAll(List<Message> messages, [bool dryRun]);
+
+  /// Sends the given multicast message to all the FCM registration tokens specified in it.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  external Promise sendMulticast(MulticastMessage message, [bool dryRun]);
+
+  /// Sends an FCM message to a condition.
+  /// 
+  /// Returns Promise<MessagingConditionResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToCondition(String condition, MessagingPayload payload, [MessagingOptions options]);
+  
+  /// Sends an FCM message to a single device corresponding to the provided registration token.
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToDevice(String registrationToken, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Sends an FCM message to a device group corresponding to the provided notification key.
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToDeviceGroup(String notificationKey, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Sends an FCM message to a topic.
+  /// 
+  /// Returns Promise<MessagingTopicResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToTopic(String topic, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Subscribes a device to an FCM topic.
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  external Promise subscribeToTopic(String registrationTokens, String topic);
+
+  /// Unsubscribes a device from an FCM topic.
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  external Promise unsubscribeFromTopic(String registrationTokens, String topic);
+}
+
+// admin.messaging ================================================================
+
+/// The Firebase Messaging service interface.
+@JS()
+@anonymous
+abstract class Messaging {
+  /// The app associated with this Messaging service instance.
+  external App get app;
+
+  /// Sends the given message via FCM.
+  /// 
+  /// Returns Promise<string> fulfilled with a unique message ID string after the 
+  /// message has been successfully handed off to the FCM service for delivery
+  external Promise send(Message message, [bool dryRun]);
+
+  /// Sends all the messages in the given array via Firebase Cloud Messaging.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  external Promise sendAll(List<Message> messages, [bool dryRun]);
+
+  /// Sends the given multicast message to all the FCM registration tokens specified in it.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  external Promise sendMulticast(MulticastMessage message, [bool dryRun]);
+
+  /// Sends an FCM message to a condition.
+  /// 
+  /// Returns Promise<MessagingConditionResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToCondition(String condition, MessagingPayload payload, [MessagingOptions options]);
+  
+  /// Sends an FCM message to a single device corresponding to the provided registration token.
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToDevice(String registrationToken, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Sends an FCM message to a device group corresponding to the provided notification key.
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToDeviceGroup(String notificationKey, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Sends an FCM message to a topic.
+  /// 
+  /// Returns Promise<MessagingTopicResponse> fulfilled with the server's response after the message has been sent.
+  external Promise sendToTopic(String topic, MessagingPayload payload, [MessagingOptions options]);
+
+  /// Subscribes a device to an FCM topic.
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  external Promise subscribeToTopic(String registrationTokens, String topic);
+
+  /// Unsubscribes a device from an FCM topic.
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  external Promise unsubscribeFromTopic(String registrationTokens, String topic);
+}
+
+@JS()
+@anonymous
+abstract class Message {
+  external String get data;
+  external Notification get notification;
+  external String get token;
+}
+
+@JS()
+@anonymous
+abstract class TopicMessage {
+  external AndroidConfig get android;
+  external ApnsConfig get apns;
+  external dynamic get data;
+  external String get key;
+  external FcmOptions get fcmOptions;
+  external Notification get notification;
+  /// Required
+  external String get topic;
+  external WebpushConfig get webpush;
+}
+
+@JS()
+@anonymous
+abstract class TokenMessage {
+  external AndroidConfig get android;
+  external ApnsConfig get apns;
+  external dynamic get data;
+  external String get key;
+  external FcmOptions get fcmOptions;
+  external Notification get notification;
+  /// Required
+  external String get token;
+  external WebpushConfig get webpush;
+}
+
+@JS()
+@anonymous
+abstract class ConditionMessage {
+  external AndroidConfig get android;
+  external ApnsConfig get apns;
+  /// Required
+  external String get condition;
+  external dynamic get data;
+  external String get key;
+  external FcmOptions get fcmOptions;
+  external Notification get notification;
+  external WebpushConfig get webpush;
+}
+
+@JS()
+@anonymous
+abstract class MulticastMessage {
+  external AndroidConfig get android;
+  external ApnsConfig get apns;
+  external dynamic get data;
+  external String get key;
+  external FcmOptions get fcmOptions;
+  external Notification get notification;
+  /// Required
+  external List<String> get tokens;
+  external WebpushConfig get webpush;
+}
+
+/// A notification that can be included in admin.messaging.Message.
+@JS()
+@anonymous
+abstract class Notification {
+  /// The notification body
+  external String get body;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+
+  /// The title of the notification.
+  external String get title;
+}
+
+/// Represents the WebPush-specific notification options that can be included in admin.messaging.WebpushConfig.
+@JS()
+@anonymous
+abstract class WebpushNotification {
+  /// An array of notification actions representing the actions available to the user when the notification is presented.
+  external List<dynamic> get actions;
+
+  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
+  external String get badge;
+
+  /// Body text of the notification.
+  external String get body;
+
+  /// Arbitrary data that you want associated with the notification. This can be of any data type.
+  external dynamic get data;
+
+  /// The direction in which to display the notification. Must be one of auto, ltr or rtl.
+  external String get dir;
+
+  /// URL to the notification icon.
+  external String get icon;
+
+  /// URL of an image to be displayed in the notification.
+  external String get image;
+
+  /// The notification's language as a BCP 47 language tag.
+  external String get lang;
+
+  /// A boolean specifying whether the user should be notified after a new notification replaces an old one. Defaults to false.
+  external bool get renotify;
+
+  /// Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. Defaults to false.
+  external bool get requireInteraction;
+
+  /// A boolean specifying whether the notification should be silent. Defaults to false.
+  external bool get silent;
+
+  /// An identifying tag for the notification.
+  external String get tag;
+
+  /// Timestamp of the notification
+  external num get timestamp;
+
+  /// Title text of the notification.
+  external String get title;
+
+  /// A vibration pattern for the device's vibration hardware to emit when the notification fires.
+  external num get vibrate;
+}
+
+/// Represents the WebPush protocol options that can be included in an admin.messaging.Message.
+@JS()
+@anonymous
+abstract class WebpushConfig {
+  /// A collection of data fields.
+  external dynamic get data;
+
+  /// Options for features provided by the FCM SDK for Web.
+  external FcmOptions get fcmOptions;
+
+  /// A collection of WebPush headers. Header values must be strings.
+  external dynamic get headers;
+
+  /// A WebPush notification payload to be included in the message.
+  external WebpushNotification get notification;
+}
+
+/// Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard).
+@JS()
+@anonymous
+abstract class WebpushFcmOptions {
+  /// The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
+  external String get link;
+}
+
+/// Options for features provided by the FCM SDK for Web.
+@JS()
+@anonymous
+abstract class FcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+}
+
+/// Interface representing a Firebase Cloud Messaging message payload. One or both of the data and notification keys are required.
+@JS()
+@anonymous
+abstract class MessagingPayload {
+  /// The data message payload.
+  external DataMessagePayload get data;
+
+  /// The notification message payload.
+  external NotificationMessagePayload get notification;
+
+  external factory MessagingPayload({
+    DataMessagePayload data,
+    NotificationMessagePayload notification,
+  });
+}
+
+/// Interface representing an FCM legacy API data message payload. Data messages let developers send up to 4KB of custom key-value pairs. The keys and values must both be strings.
+@JS()
+@anonymous
+abstract class DataMessagePayload {
+  /// Keys can be any custom string, except for the following reserved strings: 
+  /// "from" and anything starting with "google."
+  external String get key;
+  external dynamic get value;
+
+  external factory DataMessagePayload({
+    String key,
+    dynamic value,
+  });
+}
+
+/// Interface representing an FCM legacy API notification message payload. Notification messages let developers send up to 4KB of predefined key-value pairs. 
+@JS()
+@anonymous
+abstract class NotificationMessagePayload {
+  /// An array of notification actions representing the actions available to the user when the notification is presented.
+  external List<dynamic> get actions;
+
+  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
+  external String get badge;
+
+  /// Body text of the notification.
+  external String get body;
+
+  /// Variable string values to be used in place of the format specifiers in body_loc_key to use to localize the body text to 
+  /// the user's current localization.
+  /// 
+  /// The value should be a stringified JSON array.
+  external String get bodyLocArgs;
+
+  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
+  external String get bodyLocKey;
+
+  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is 
+  /// launched when a user clicks on the notification.
+  external String get clickAction;
+
+  /// The notification icon's color, expressed in #rrggbb format.
+  external String get color;
+
+  /// URL to the notification icon.
+  external String get icon;
+
+  /// Identifier used to replace existing notifications in the notification drawer.
+  external String get sound;
+
+  /// An identifying tag for the notification.
+  external String get tag;
+
+  /// The notification's title.
+  external String get title;
+
+  /// Variable string values to be used in place of the format specifiers in title_loc_key to use to localize the 
+  /// title text to the user's current localization.
+  /// The value should be a stringified JSON array.
+  external String get titleLocArgs;
+
+  /// The key to the title string in the app's string resources to use to localize the title text to the user's current localization.
+  external String get titleLocKey;
+}
+
+/// Interface representing the options that can be provided when sending a message via the FCM legacy APIs.
+@JS()
+@anonymous
+abstract class MessagingOptions {
+  /// String identifying a group of messages (for example, "Updates Available") that can be collapsed, so that only the last message 
+  /// gets sent when delivery can be resumed. This is used to avoid sending too many of the same messages when the device comes back online or becomes active.
+  external String get collapseKey;
+
+  /// On iOS, use this field to represent content-available in the APNs payload. When a notification or data message is sent and this is set to true, 
+  /// an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, this flag is currently not supported.
+  external bool get contentAvailable;
+
+  /// Whether or not the message should actually be sent. When set to true, allows developers to test a request without actually sending a message. 
+  /// When set to false, the message will be sent.
+  external bool get dryRun;
+
+  /// On iOS, use this field to represent mutable-content in the APNs payload. When a notification is sent and this is set to true, the content of the 
+  /// notification can be modified before it is displayed, using a Notification Service app extension
+  /// On Android and Web, this parameter will be ignored.
+  external bool get mutableContent;
+
+  /// The priority of the message. Valid values are "normal" and "high". On iOS, these correspond to APNs priorities 5 and 10.
+  external String get priority;
+
+  /// The package name of the application which the registration tokens must match in order to receive the message.
+  external String get restrictedPackageName;
+
+  /// How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. 
+  external num get timeToLive;
+}
+
+/// Represents the Android-specific options that can be included in an admin.messaging.Message.
+@JS()
+@anonymous
+abstract class AndroidConfig {
+  /// Collapse key for the message. Collapse key serves as an identifier for a group of messages that can be collapsed, so that only 
+  /// the last message gets sent when delivery can be resumed. A maximum of four different collapse keys may be active at any given time.
+  external String get collapseKey;
+
+  /// A collection of data fields to be included in the message. All values must be strings. When provided, overrides any data fields 
+  /// set on the top-level admin.messaging.Message.
+  external dynamic get data;
+
+  /// Options for features provided by the FCM SDK for Android.
+  external AndroidFcmOptions get fcmOptions;
+
+  /// Android notification to be included in the message.
+  external AndroidNotification get notification;
+
+  /// Priority of the message. Must be either normal or high.
+  external String get priority;
+
+  /// Package name of the application where the registration tokens must match in order to receive the message.
+  external String get restrictedPackageName;
+
+  /// Time-to-live duration of the message in milliseconds.
+  external num get ttl;
+}
+
+/// Represents options for features provided by the FCM SDK for Android.
+@JS()
+@anonymous
+abstract class AndroidFcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+}
+
+/// Represents the Android-specific notification options that can be included in admin.messaging.AndroidConfig.
+@JS()
+@anonymous
+abstract class AndroidNotification {
+  /// Body of the Android notification. When provided, overrides the body set via admin.messaging.Notification
+  external String get body;
+
+  /// An array of resource keys that will be used in place of the format specifiers in bodyLocKey.
+  external List<String> get bodyLocArgs;
+
+  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
+  external String get bodyLocKey;
+
+  /// The Android notification channel ID (new in Android O). 
+  external String get channelId;
+
+  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.
+  external String get clickAction;
+
+  /// Notification icon color in #rrggbb format.
+  external String get color;
+
+  /// Icon resource for the Android notification.
+  external String get icon;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+
+  /// File name of the sound to be played when the device receives the notification.
+  external String get sound;
+
+  /// Notification tag. This is an identifier used to replace existing notifications
+  /// in the notification drawer. If not specified, each request creates a new notification.
+  external String get tag;
+
+  /// Title of the Android notification. When provided, overrides the title set via admin.messaging.Notification.
+  external String get title;
+
+  /// An array of resource keys that will be used in place of the format specifiers in titleLocKey.
+  external List<String> get titleLocArgs;
+
+  /// Key of the title string in the app's string resource to use to localize the title text.
+  external String get titleLocKey;
+}
+
+/// Represents the APNs-specific options that can be included in an admin.messaging.Message. 
+@JS()
+@anonymous
+abstract class ApnsConfig {
+  /// Options for features provided by the FCM SDK for iOS.
+  external ApnsFcmOptions get fcmOptions;
+
+  /// A collection of APNs headers. Header values must be strings.
+  external dynamic get headers;
+
+  /// An APNs payload to be included in the message.
+  external ApnsPayload get payload;
+}
+
+/// Represents options for features provided by the FCM SDK for iOS.
+@JS()
+@anonymous
+abstract class ApnsFcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+}
+
+/// Represents options for features provided by the FCM SDK for iOS.
+@JS()
+@anonymous
+abstract class ApnsPayload {
+  /// The aps dictionary to be included in the message.
+  external Aps get aps;
+}
+
+/// Represents the aps dictionary that is part of APNs messages.
+@JS()
+@anonymous
+abstract class Aps {
+  /// Alert to be included in the message. This may be a string or an object of type admin.messaging.ApsAlert
+  external String get alert;
+
+  /// Badge to be displayed with the message. Set to 0 to remove the badge. When not specified, the badge will remain unchanged.
+  external num get badge;
+
+  /// Type of the notification.
+  external String get category;
+
+  /// Specifies whether to configure a background update notification.
+  external bool get contentAvailable;
+
+  /// Specifies whether to set the mutable-content property on the message so the clients can modify the notification via app extensions.
+  external bool get mutableContent;
+
+  /// Sound to be played with the message.
+  external String get sound;
+
+  /// An app-specific identifier for grouping notifications.
+  external String get threadId;
+}
+
+@JS()
+@anonymous
+abstract class ApsAlert {
+  external String get actionLocKey;
+  external String get body;
+  external String get launchImage;
+  external List<String> get locArgs;
+  external String get locKey;
+  external String get subtitle;
+  external List<String> get subtitleLocArgs;
+  external String get subtitleLocKey;
+  external String get title;
+  external List<String> get titleLocArgs;
+  external String get titleLocKey;
+}
+
+/// Represents a critical sound configuration that can be included in the aps dictionary of an APNs payload.
+@JS()
+@anonymous
+abstract class CriticalSound {
+  /// The critical alert flag. Set to true to enable the critical alert.
+  external bool get critical;
+
+  /// The name of a sound file in the app's main bundle or in the Library/Sounds folder of the app's container directory. 
+  /// Specify the string "default" to play the system sound.
+  external String get name;
+
+  /// The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume).
+  external num get volume;
+
+}
+/// Interface representing the server response from the sendAll() and sendMulticast() methods.
+@JS()
+@anonymous
+abstract class BatchResponse {
+  /// The number of messages that resulted in errors when sending.
+  external num get failureCount;
+
+  /// An array of responses, each corresponding to a message.
+  external List<SendResponse> get responses;
+
+  /// The number of messages that were successfully handed off for sending.
+  external num get successCount;
+}
+
+/// Interface representing the status of an individual message that was sent as part of a batch request.
+@JS()
+@anonymous
+abstract class SendResponse {
+  /// An error, if the message was not handed off to FCM successfully.
+  external FirebaseError get error;
+
+  /// A unique message ID string, if the message was handed off to FCM for delivery.
+  external String get messageId;
+
+  /// A boolean indicating if the message was successfully handed off to FCM or not. When true, the 
+  /// messageId attribute is guaranteed to be set. When false, the error attribute is guaranteed to be set.
+  external bool get success;
+}
+
+/// Interface representing the server response from the legacy sendToCondition() method.
+@JS()
+@anonymous
+abstract class MessagingConditionResponse {
+  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+  external num get messageId;
+}
+
+/// Interface representing the server response from the sendToDeviceGroup() method.
+@JS()
+@anonymous
+abstract class MessagingDeviceGroupResponse {
+  /// An array of registration tokens that failed to receive the message.
+  external List<String> get failedRegistrationTokens;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get failureCount;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get successCount;
+}
+
+/// Interface representing the status of a message sent to an individual device via the FCM legacy APIs.
+@JS()
+@anonymous
+abstract class MessagingDeviceResult {
+  /// The canonical registration token for the client app that the message was processed and sent to. 
+  /// You should use this value as the registration token for future requests. Otherwise, 
+  /// future messages might be rejected.
+  external String get canonicalRegistrationToken;
+
+  /// The error that occurred when processing the message for the recipient.
+  external FirebaseError get error;
+
+  /// A unique ID for the successfully processed message.
+  external String get messageId;
+}
+
+/// Interface representing the server response from the legacy sendToDevice() method.
+@JS()
+@anonymous
+abstract class MessagingDevicesResponse {
+  /// The number of results that contain a canonical registration token. A canonical registration token 
+  /// is the registration token corresponding to the last registration requested by the client app. 
+  /// This is the token that you should use when sending future messages to the device.
+  /// You can access the canonical registration tokens within the results property.
+  external num get canonicalRegistrationTokenCount;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get failureCount;
+
+  /// The unique ID number identifying this multicast message.
+  external num get multicastId;
+
+  /// An array of [MessagingDeviceResult] objects representing the status of the processed messages. 
+  /// The objects are listed in the same order as in the request. That is, for each registration token 
+  /// in the request, its result has the same index in this array. 
+  /// If only a single registration token is provided, this array will contain a single object.
+  external List<MessagingDeviceResult> get results;
+
+  /// The number of messages that were successfully processed and sent.
+  external num get successCount;
+}
+
+/// Interface representing the server response from the legacy sendToTopic() method.
+@JS()
+@anonymous
+abstract class MessagingTopicResponse {
+  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+  external num get messageId;
+}
+
+/// Interface representing the server response from the subscribeToTopic() and 
+/// admin.messaging.Messaging#unsubscribeFromTopic unsubscribeFromTopic() methods.
+@JS()
+@anonymous
+abstract class MessagingTopicManagementResponse {
+  /// An array of errors corresponding to the provided registration token(s). The length of this array will be equal to failureCount.
+  external List<FirebaseArrayIndexError> get errors;
+
+  /// The number of registration tokens that could not be subscribed to the topic and resulted in an error.
+  external num get failureCount;
+
+  /// The number of registration tokens that were successfully subscribed to the topic.
+  external num get successCount;
+}
+
+/// A notification that can be included in admin.messaging.Message.
+@JS()
+@anonymous
+abstract class Notification {
+  /// The notification body
+  external String get body;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+
+  /// The title of the notification.
+  external String get title;
+}
+
+/// Represents the WebPush-specific notification options that can be included in admin.messaging.WebpushConfig.
+@JS()
+@anonymous
+abstract class WebpushNotification {
+  /// An array of notification actions representing the actions available to the user when the notification is presented.
+  external List<dynamic> get actions;
+
+  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
+  external String get badge;
+
+  /// Body text of the notification.
+  external String get body;
+
+  /// Arbitrary data that you want associated with the notification. This can be of any data type.
+  external dynamic get data;
+
+  /// The direction in which to display the notification. Must be one of auto, ltr or rtl.
+  external String get dir;
+
+  /// URL to the notification icon.
+  external String get icon;
+
+  /// URL of an image to be displayed in the notification.
+  external String get image;
+
+  /// The notification's language as a BCP 47 language tag.
+  external String get lang;
+
+  /// A boolean specifying whether the user should be notified after a new notification replaces an old one. Defaults to false.
+  external bool get renotify;
+
+  /// Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. Defaults to false.
+  external bool get requireInteraction;
+
+  /// A boolean specifying whether the notification should be silent. Defaults to false.
+  external bool get silent;
+
+  /// An identifying tag for the notification.
+  external String get tag;
+
+  /// Timestamp of the notification
+  external num get timestamp;
+
+  /// Title text of the notification.
+  external String get title;
+
+  /// A vibration pattern for the device's vibration hardware to emit when the notification fires.
+  external num get vibrate;
+}
+
+/// Represents the WebPush protocol options that can be included in an admin.messaging.Message.
+@JS()
+@anonymous
+abstract class WebpushConfig {
+  /// A collection of data fields.
+  external dynamic get data;
+
+  /// Options for features provided by the FCM SDK for Web.
+  external FcmOptions get fcmOptions;
+
+  /// A collection of WebPush headers. Header values must be strings.
+  external dynamic get headers;
+
+  /// A WebPush notification payload to be included in the message.
+  external WebpushNotification get notification;
+}
+
+/// Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard).
+@JS()
+@anonymous
+abstract class WebpushFcmOptions {
+  /// The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
+  external String get link;
+}
+
+/// Options for features provided by the FCM SDK for Web.
+@JS()
+@anonymous
+abstract class FcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+}
+
+/// Interface representing a Firebase Cloud Messaging message payload. One or both of the data and notification keys are required.
+@JS()
+@anonymous
+abstract class MessagingPayload {
+  /// The data message payload.
+  external DataMessagePayload get data;
+
+  /// The notification message payload.
+  external NotificationMessagePayload get notification;
+}
+
+/// Interface representing an FCM legacy API data message payload. Data messages let developers send up to 4KB of custom key-value pairs. The keys and values must both be strings.
+@JS()
+@anonymous
+abstract class DataMessagePayload {
+  /// Keys can be any custom string, except for the following reserved strings: 
+  /// "from" and anything starting with "google."
+  external String get key;
+
+  external dynamic get value;
+}
+
+/// Interface representing an FCM legacy API notification message payload. Notification messages let developers send up to 4KB of predefined key-value pairs. 
+@JS()
+@anonymous
+abstract class NotificationMessagePayload {
+  /// An array of notification actions representing the actions available to the user when the notification is presented.
+  external List<dynamic> get actions;
+
+  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
+  external String get badge;
+
+  /// Body text of the notification.
+  external String get body;
+
+  /// Variable string values to be used in place of the format specifiers in body_loc_key to use to localize the body text to 
+  /// the user's current localization.
+  /// 
+  /// The value should be a stringified JSON array.
+  external String get bodyLocArgs;
+
+  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
+  external String get bodyLocKey;
+
+  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is 
+  /// launched when a user clicks on the notification.
+  external String get clickAction;
+
+  /// The notification icon's color, expressed in #rrggbb format.
+  external String get color;
+
+  /// URL to the notification icon.
+  external String get icon;
+
+  /// Identifier used to replace existing notifications in the notification drawer.
+  external String get sound;
+
+  /// An identifying tag for the notification.
+  external String get tag;
+
+  /// The notification's title.
+  external String get title;
+
+  /// Variable string values to be used in place of the format specifiers in title_loc_key to use to localize the 
+  /// title text to the user's current localization.
+  /// The value should be a stringified JSON array.
+  external String get titleLocArgs;
+
+  /// The key to the title string in the app's string resources to use to localize the title text to the user's current localization.
+  external String get titleLocKey;
+}
+
+/// Interface representing the options that can be provided when sending a message via the FCM legacy APIs.
+@JS()
+@anonymous
+abstract class MessagingOptions {
+  /// String identifying a group of messages (for example, "Updates Available") that can be collapsed, so that only the last message 
+  /// gets sent when delivery can be resumed. This is used to avoid sending too many of the same messages when the device comes back online or becomes active.
+  external String get collapseKey;
+
+  /// On iOS, use this field to represent content-available in the APNs payload. When a notification or data message is sent and this is set to true, 
+  /// an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, this flag is currently not supported.
+  external bool get contentAvailable;
+
+  /// Whether or not the message should actually be sent. When set to true, allows developers to test a request without actually sending a message. 
+  /// When set to false, the message will be sent.
+  external bool get dryRun;
+
+  /// On iOS, use this field to represent mutable-content in the APNs payload. When a notification is sent and this is set to true, the content of the 
+  /// notification can be modified before it is displayed, using a Notification Service app extension
+  /// On Android and Web, this parameter will be ignored.
+  external bool get mutableContent;
+
+  /// The priority of the message. Valid values are "normal" and "high". On iOS, these correspond to APNs priorities 5 and 10.
+  external String get priority;
+
+  /// The package name of the application which the registration tokens must match in order to receive the message.
+  external String get restrictedPackageName;
+
+  /// How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. 
+  external num get timeToLive;
+}
+
+/// Represents the Android-specific options that can be included in an admin.messaging.Message.
+@JS()
+@anonymous
+abstract class AndroidConfig {
+  /// Collapse key for the message. Collapse key serves as an identifier for a group of messages that can be collapsed, so that only 
+  /// the last message gets sent when delivery can be resumed. A maximum of four different collapse keys may be active at any given time.
+  external String get collapseKey;
+
+  /// A collection of data fields to be included in the message. All values must be strings. When provided, overrides any data fields 
+  /// set on the top-level admin.messaging.Message.
+  external dynamic get data;
+
+  /// Options for features provided by the FCM SDK for Android.
+  external AndroidFcmOptions get fcmOptions;
+
+  /// Android notification to be included in the message.
+  external AndroidNotification get notification;
+
+  /// Priority of the message. Must be either normal or high.
+  external String get priority;
+
+  /// Package name of the application where the registration tokens must match in order to receive the message.
+  external String get restrictedPackageName;
+
+  /// Time-to-live duration of the message in milliseconds.
+  external num get ttl;
+}
+
+/// Represents options for features provided by the FCM SDK for Android.
+@JS()
+@anonymous
+abstract class AndroidFcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+}
+
+/// Represents the Android-specific notification options that can be included in admin.messaging.AndroidConfig.
+@JS()
+@anonymous
+abstract class AndroidNotification {
+  /// Body of the Android notification. When provided, overrides the body set via admin.messaging.Notification
+  external String get body;
+
+  /// An array of resource keys that will be used in place of the format specifiers in bodyLocKey.
+  external List<String> get bodyLocArgs;
+
+  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
+  external String get bodyLocKey;
+
+  /// The Android notification channel ID (new in Android O). 
+  external String get channelId;
+
+  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.
+  external String get clickAction;
+
+  /// Notification icon color in #rrggbb format.
+  external String get color;
+
+  /// Icon resource for the Android notification.
+  external String get icon;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+
+  /// File name of the sound to be played when the device receives the notification.
+  external String get sound;
+
+  /// Notification tag. This is an identifier used to replace existing notifications
+  /// in the notification drawer. If not specified, each request creates a new notification.
+  external String get tag;
+
+  /// Title of the Android notification. When provided, overrides the title set via admin.messaging.Notification.
+  external String get title;
+
+  /// An array of resource keys that will be used in place of the format specifiers in titleLocKey.
+  external List<String> get titleLocArgs;
+
+  /// Key of the title string in the app's string resource to use to localize the title text.
+  external String get titleLocKey;
+}
+
+/// Represents the APNs-specific options that can be included in an admin.messaging.Message. 
+@JS()
+@anonymous
+abstract class ApnsConfig {
+  /// Options for features provided by the FCM SDK for iOS.
+  external ApnsFcmOptions get fcmOptions;
+
+  /// A collection of APNs headers. Header values must be strings.
+  external dynamic get headers;
+
+  /// An APNs payload to be included in the message.
+  external ApnsPayload get payload;
+}
+
+/// Represents options for features provided by the FCM SDK for iOS.
+@JS()
+@anonymous
+abstract class ApnsFcmOptions {
+  /// The label associated with the message's analytics data.
+  external String get analyticsLabel;
+
+  /// URL of an image to be displayed in the notification.
+  external String get imageUrl;
+}
+
+/// Represents options for features provided by the FCM SDK for iOS.
+@JS()
+@anonymous
+abstract class ApnsPayload {
+  /// The aps dictionary to be included in the message.
+  external Aps get aps;
+}
+
+/// Represents the aps dictionary that is part of APNs messages.
+@JS()
+@anonymous
+abstract class Aps {
+  /// Alert to be included in the message. This may be a string or an object of type admin.messaging.ApsAlert
+  external String get alert;
+
+  /// Badge to be displayed with the message. Set to 0 to remove the badge. When not specified, the badge will remain unchanged.
+  external num get badge;
+
+  /// Type of the notification.
+  external String get category;
+
+  /// Specifies whether to configure a background update notification.
+  external bool get contentAvailable;
+
+  /// Specifies whether to set the mutable-content property on the message so the clients can modify the notification via app extensions.
+  external bool get mutableContent;
+
+  /// Sound to be played with the message.
+  external String get sound;
+
+  /// An app-specific identifier for grouping notifications.
+  external String get threadId;
+}
+
+@JS()
+@anonymous
+abstract class ApsAlert {
+  external String get actionLocKey;
+  external String get body;
+  external String get launchImage;
+  external List<String> get locArgs;
+  external String get locKey;
+  external String get subtitle;
+  external List<String> get subtitleLocArgs;
+  external String get subtitleLocKey;
+  external String get title;
+  external List<String> get titleLocArgs;
+  external String get titleLocKey;
+}
+
+/// Represents a critical sound configuration that can be included in the aps dictionary of an APNs payload.
+@JS()
+@anonymous
+abstract class CriticalSound {
+  /// The critical alert flag. Set to true to enable the critical alert.
+  external bool get critical;
+
+  /// The name of a sound file in the app's main bundle or in the Library/Sounds folder of the app's container directory. 
+  /// Specify the string "default" to play the system sound.
+  external String get name;
+
+  /// The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume).
+  external num get volume;
+
+}
+/// Interface representing the server response from the sendAll() and sendMulticast() methods.
+@JS()
+@anonymous
+abstract class BatchResponse {
+  /// The number of messages that resulted in errors when sending.
+  external num get failureCount;
+
+  /// An array of responses, each corresponding to a message.
+  external List<SendResponse> get responses;
+
+  /// The number of messages that were successfully handed off for sending.
+  external num get successCount;
+}
+
+/// Interface representing the status of an individual message that was sent as part of a batch request.
+@JS()
+@anonymous
+abstract class SendResponse {
+  /// An error, if the message was not handed off to FCM successfully.
+  external FirebaseError get error;
+
+  /// A unique message ID string, if the message was handed off to FCM for delivery.
+  external String get messageId;
+
+  /// A boolean indicating if the message was successfully handed off to FCM or not. When true, the 
+  /// messageId attribute is guaranteed to be set. When false, the error attribute is guaranteed to be set.
+  external bool get success;
+}
+
+/// Interface representing the server response from the legacy sendToCondition() method.
+@JS()
+@anonymous
+abstract class MessagingConditionResponse {
+  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+  external num get messageId;
+}
+
+/// Interface representing the server response from the sendToDeviceGroup() method.
+@JS()
+@anonymous
+abstract class MessagingDeviceGroupResponse {
+  /// An array of registration tokens that failed to receive the message.
+  external List<String> get failedRegistrationTokens;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get failureCount;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get successCount;
+}
+
+/// Interface representing the status of a message sent to an individual device via the FCM legacy APIs.
+@JS()
+@anonymous
+abstract class MessagingDeviceResult {
+  /// The canonical registration token for the client app that the message was processed and sent to. 
+  /// You should use this value as the registration token for future requests. Otherwise, 
+  /// future messages might be rejected.
+  external String get canonicalRegistrationToken;
+
+  /// The error that occurred when processing the message for the recipient.
+  external FirebaseError get error;
+
+  /// A unique ID for the successfully processed message.
+  external String get messageId;
+}
+
+/// Interface representing the server response from the legacy sendToDevice() method.
+@JS()
+@anonymous
+abstract class MessagingDevicesResponse {
+  /// The number of results that contain a canonical registration token. A canonical registration token 
+  /// is the registration token corresponding to the last registration requested by the client app. 
+  /// This is the token that you should use when sending future messages to the device.
+  /// You can access the canonical registration tokens within the results property.
+  external num get canonicalRegistrationTokenCount;
+
+  /// The number of messages that could not be processed and resulted in an error.
+  external num get failureCount;
+
+  /// The unique ID number identifying this multicast message.
+  external num get multicastId;
+
+  /// An array of [MessagingDeviceResult] objects representing the status of the processed messages. 
+  /// The objects are listed in the same order as in the request. That is, for each registration token 
+  /// in the request, its result has the same index in this array. 
+  /// If only a single registration token is provided, this array will contain a single object.
+  external List<MessagingDeviceResult> get results;
+
+  /// The number of messages that were successfully processed and sent.
+  external num get successCount;
+}
+
+/// Interface representing the server response from the legacy sendToTopic() method.
+@JS()
+@anonymous
+abstract class MessagingTopicResponse {
+  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+  external num get messageId;
+}
+
+/// Interface representing the server response from the subscribeToTopic() and 
+/// admin.messaging.Messaging#unsubscribeFromTopic unsubscribeFromTopic() methods.
+@JS()
+@anonymous
+abstract class MessagingTopicManagementResponse {
+  /// An array of errors corresponding to the provided registration token(s). The length of this array will be equal to failureCount.
+  external List<FirebaseArrayIndexError> get errors;
+
+  /// The number of registration tokens that could not be subscribed to the topic and resulted in an error.
+  external num get failureCount;
+
+  /// The number of registration tokens that were successfully subscribed to the topic.
+  external num get successCount;
 }
 
 // admin.database ================================================================

--- a/lib/src/bindings.dart
+++ b/lib/src/bindings.dart
@@ -656,10 +656,16 @@ abstract class Messaging {
 
 @JS()
 @anonymous
-abstract class Message {
+abstract class FcmMessage {
   external String get data;
   external Notification get notification;
   external String get token;
+  
+  external factory FcmMessage({
+    String data, 
+    Notification notification, 
+    String token,
+  });
 }
 
 @JS()
@@ -674,6 +680,17 @@ abstract class TopicMessage {
   /// Required
   external String get topic;
   external WebpushConfig get webpush;
+  
+  external factory TopicMessage({
+    AndroidConfig android,
+    ApnsConfig apns,
+    dynamic data,
+    String key,
+    FcmOptions fcmOptions,
+    Notification notification,
+    String topic,
+    WebpushConfig webpush,
+  });
 }
 
 @JS()
@@ -688,6 +705,17 @@ abstract class TokenMessage {
   /// Required
   external String get token;
   external WebpushConfig get webpush;
+  
+  external factory TokenMessage({
+    AndroidConfig android,
+    ApnsConfig apns,
+    dynamic data,
+    String key,
+    FcmOptions fcmOptions,
+    Notification notification,
+    String token,
+    WebpushConfig webpush,
+  });
 }
 
 @JS()
@@ -702,6 +730,17 @@ abstract class ConditionMessage {
   external FcmOptions get fcmOptions;
   external Notification get notification;
   external WebpushConfig get webpush;
+  
+  external factory ConditionMessage({
+    AndroidConfig android,
+    ApnsConfig apns,
+    String condition,
+    dynamic data,
+    String key,
+    FcmOptions fcmOptions,
+    Notification notification,
+    WebpushConfig webpush,
+  });
 }
 
 @JS()
@@ -716,6 +755,17 @@ abstract class MulticastMessage {
   /// Required
   external List<String> get tokens;
   external WebpushConfig get webpush;
+  
+  external factory MulticastMessage({
+    AndroidConfig android,
+    ApnsConfig apns,
+    dynamic data,
+    String key,
+    FcmOptions fcmOptions,
+    Notification notification,
+    List<String> tokens,
+    WebpushConfig webpush,
+  });
 }
 
 /// A notification that can be included in admin.messaging.Message.
@@ -730,6 +780,12 @@ abstract class Notification {
 
   /// The title of the notification.
   external String get title;
+  
+  external factory Notification({
+    String body,
+    String imageUrl,
+    String title,
+  });
 }
 
 /// Represents the WebPush-specific notification options that can be included in admin.messaging.WebpushConfig.
@@ -780,6 +836,24 @@ abstract class WebpushNotification {
 
   /// A vibration pattern for the device's vibration hardware to emit when the notification fires.
   external num get vibrate;
+  
+  external factory WebpushNotification ({
+    List<dynamic> actions,
+    String badge,
+    String body,
+    dynamic data,
+    String dir,
+    String icon,
+    String image,
+    String lang,
+    bool renotify,
+    bool requireInteraction,
+    bool silent,
+    String tag,
+    num timestamp,
+    String title,
+    num vibrate,
+  });
 }
 
 /// Represents the WebPush protocol options that can be included in an admin.messaging.Message.
@@ -797,6 +871,13 @@ abstract class WebpushConfig {
 
   /// A WebPush notification payload to be included in the message.
   external WebpushNotification get notification;
+  
+  external factory WebpushConfig({
+    dynamic data,
+    FcmOptions fcmOptions,
+    dynamic headers,
+    WebpushNotification notification,
+  });
 }
 
 /// Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard).
@@ -805,6 +886,10 @@ abstract class WebpushConfig {
 abstract class WebpushFcmOptions {
   /// The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
   external String get link;
+  
+  external factory WebpushFcmOptions({
+    String link,
+  });
 }
 
 /// Options for features provided by the FCM SDK for Web.
@@ -813,6 +898,10 @@ abstract class WebpushFcmOptions {
 abstract class FcmOptions {
   /// The label associated with the message's analytics data.
   external String get analyticsLabel;
+  
+  external factory FcmOptions({
+    String analyticsLabel,
+  });
 }
 
 /// Interface representing a Firebase Cloud Messaging message payload. One or both of the data and notification keys are required.
@@ -894,6 +983,22 @@ abstract class NotificationMessagePayload {
 
   /// The key to the title string in the app's string resources to use to localize the title text to the user's current localization.
   external String get titleLocKey;
+  
+  external factory NotificationMessagePayload({
+    List<dynamic> actions,
+    String badge,
+    String body,
+    String bodyLocArgs,
+    String bodyLocKey,
+    String clickAction,
+    String color,
+    String icon,
+    String sound,
+    String tag,
+    String title,
+    String titleLocArgs,
+    String titleLocKey,
+  });
 }
 
 /// Interface representing the options that can be provided when sending a message via the FCM legacy APIs.
@@ -925,6 +1030,16 @@ abstract class MessagingOptions {
 
   /// How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. 
   external num get timeToLive;
+  
+  external factory MessagingOptions({
+    String collapseKey,
+    bool contentAvailable,
+    bool dryRun,
+    bool mutableContent,
+    String priority,
+    String restrictedPackageName,
+    num timeToLive,
+  });
 }
 
 /// Represents the Android-specific options that can be included in an admin.messaging.Message.
@@ -953,6 +1068,16 @@ abstract class AndroidConfig {
 
   /// Time-to-live duration of the message in milliseconds.
   external num get ttl;
+  
+  external factory AndroidConfig({
+    String collapseKey,
+    dynamic data,
+    AndroidFcmOptions fcmOptions,
+    AndroidNotification notification,
+    String priority,
+    String restrictedPackageName,
+    num ttl,
+  });
 }
 
 /// Represents options for features provided by the FCM SDK for Android.
@@ -961,6 +1086,10 @@ abstract class AndroidConfig {
 abstract class AndroidFcmOptions {
   /// The label associated with the message's analytics data.
   external String get analyticsLabel;
+  
+  external factory AndroidFcmOptions({
+    String analyticsLabel,
+  });
 }
 
 /// Represents the Android-specific notification options that can be included in admin.messaging.AndroidConfig.
@@ -1006,6 +1135,22 @@ abstract class AndroidNotification {
 
   /// Key of the title string in the app's string resource to use to localize the title text.
   external String get titleLocKey;
+  
+  external factory AndroidNotification({
+    String body,
+    List<String> bodyLocArgs,
+    String bodyLocKey,
+    String channelId,
+    String clickAction,
+    String color,
+    String icon,
+    String imageUrl,
+    String sound,
+    String tag,
+    String title,
+    List<String> titleLocArgs,
+    String titleLocKey,
+  });
 }
 
 /// Represents the APNs-specific options that can be included in an admin.messaging.Message. 
@@ -1020,6 +1165,12 @@ abstract class ApnsConfig {
 
   /// An APNs payload to be included in the message.
   external ApnsPayload get payload;
+  
+  external factory ApnsConfig({
+    ApnsFcmOptions fcmOptions,
+    dynamic headers,
+    ApnsPayload payload,
+  });
 }
 
 /// Represents options for features provided by the FCM SDK for iOS.
@@ -1031,6 +1182,11 @@ abstract class ApnsFcmOptions {
 
   /// URL of an image to be displayed in the notification.
   external String get imageUrl;
+  
+  external factory ApnsFcmOptions({
+    String analyticsLabel,
+    String imageUrl
+  });
 }
 
 /// Represents options for features provided by the FCM SDK for iOS.
@@ -1039,6 +1195,10 @@ abstract class ApnsFcmOptions {
 abstract class ApnsPayload {
   /// The aps dictionary to be included in the message.
   external Aps get aps;
+  
+  external factory ApnsPayload({
+    Aps aps,
+  });
 }
 
 /// Represents the aps dictionary that is part of APNs messages.
@@ -1065,6 +1225,15 @@ abstract class Aps {
 
   /// An app-specific identifier for grouping notifications.
   external String get threadId;
+  
+  external factory Aps({
+    String alert,
+    num badge,
+    String category,
+    bool contentAvailable,
+    bool mutableContent,
+    String sound,
+  });
 }
 
 @JS()
@@ -1081,6 +1250,20 @@ abstract class ApsAlert {
   external String get title;
   external List<String> get titleLocArgs;
   external String get titleLocKey;
+  
+  external factory ApsAlert({
+    String actionLocKey,
+    String body,
+    String launchImage,
+    List<String> locArgs,
+    String locKey,
+    String subtitle,
+    List<String> subtitleLocArgs,
+    String subtitleLocKey,
+    String title,
+    List<String> titleLocArgs,
+    String titleLocKey,
+  });
 }
 
 /// Represents a critical sound configuration that can be included in the aps dictionary of an APNs payload.
@@ -1096,7 +1279,12 @@ abstract class CriticalSound {
 
   /// The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume).
   external num get volume;
-
+  
+  external factory CriticalSound({
+    bool critical,
+    String name,
+    num volume,
+  });
 }
 /// Interface representing the server response from the sendAll() and sendMulticast() methods.
 @JS()
@@ -1110,6 +1298,12 @@ abstract class BatchResponse {
 
   /// The number of messages that were successfully handed off for sending.
   external num get successCount;
+  
+  external factory BatchResponse({
+    num failureCount,
+    List<SendResponse> responses,
+    num successCount,
+  });
 }
 
 /// Interface representing the status of an individual message that was sent as part of a batch request.
@@ -1125,6 +1319,12 @@ abstract class SendResponse {
   /// A boolean indicating if the message was successfully handed off to FCM or not. When true, the 
   /// messageId attribute is guaranteed to be set. When false, the error attribute is guaranteed to be set.
   external bool get success;
+  
+  external factory SendResponse({
+    FirebaseError error,
+    String messageId,
+    bool success,
+  });
 }
 
 /// Interface representing the server response from the legacy sendToCondition() method.
@@ -1133,6 +1333,10 @@ abstract class SendResponse {
 abstract class MessagingConditionResponse {
   /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
   external num get messageId;
+  
+  external factory MessagingConditionResponse({
+    num messageId,
+  });
 }
 
 /// Interface representing the server response from the sendToDeviceGroup() method.
@@ -1147,6 +1351,12 @@ abstract class MessagingDeviceGroupResponse {
 
   /// The number of messages that could not be processed and resulted in an error.
   external num get successCount;
+  
+  external factory MessagingDeviceGroupResponse({
+    List<String> failedRegistrationTokens,
+    num failureCount,
+    num successCount,
+  });
 }
 
 /// Interface representing the status of a message sent to an individual device via the FCM legacy APIs.
@@ -1163,6 +1373,12 @@ abstract class MessagingDeviceResult {
 
   /// A unique ID for the successfully processed message.
   external String get messageId;
+  
+  external factory MessagingDeviceResult({
+    String canonicalRegistrationToken,
+    FirebaseError error,
+    String messageId,
+  });
 }
 
 /// Interface representing the server response from the legacy sendToDevice() method.
@@ -1189,6 +1405,14 @@ abstract class MessagingDevicesResponse {
 
   /// The number of messages that were successfully processed and sent.
   external num get successCount;
+  
+  external factory MessagingDevicesResponse({
+    num canonicalRegistrationTokenCount,
+    num failureCount,
+    num multicastId,
+    List<MessagingDeviceResult> results,
+    num successCount,
+  });
 }
 
 /// Interface representing the server response from the legacy sendToTopic() method.
@@ -1197,6 +1421,10 @@ abstract class MessagingDevicesResponse {
 abstract class MessagingTopicResponse {
   /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
   external num get messageId;
+  
+  external factory MessagingTopicResponse({
+    num messageId,
+  });
 }
 
 /// Interface representing the server response from the subscribeToTopic() and 
@@ -1212,493 +1440,12 @@ abstract class MessagingTopicManagementResponse {
 
   /// The number of registration tokens that were successfully subscribed to the topic.
   external num get successCount;
-}
-
-/// A notification that can be included in admin.messaging.Message.
-@JS()
-@anonymous
-abstract class Notification {
-  /// The notification body
-  external String get body;
-
-  /// URL of an image to be displayed in the notification.
-  external String get imageUrl;
-
-  /// The title of the notification.
-  external String get title;
-}
-
-/// Represents the WebPush-specific notification options that can be included in admin.messaging.WebpushConfig.
-@JS()
-@anonymous
-abstract class WebpushNotification {
-  /// An array of notification actions representing the actions available to the user when the notification is presented.
-  external List<dynamic> get actions;
-
-  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
-  external String get badge;
-
-  /// Body text of the notification.
-  external String get body;
-
-  /// Arbitrary data that you want associated with the notification. This can be of any data type.
-  external dynamic get data;
-
-  /// The direction in which to display the notification. Must be one of auto, ltr or rtl.
-  external String get dir;
-
-  /// URL to the notification icon.
-  external String get icon;
-
-  /// URL of an image to be displayed in the notification.
-  external String get image;
-
-  /// The notification's language as a BCP 47 language tag.
-  external String get lang;
-
-  /// A boolean specifying whether the user should be notified after a new notification replaces an old one. Defaults to false.
-  external bool get renotify;
-
-  /// Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. Defaults to false.
-  external bool get requireInteraction;
-
-  /// A boolean specifying whether the notification should be silent. Defaults to false.
-  external bool get silent;
-
-  /// An identifying tag for the notification.
-  external String get tag;
-
-  /// Timestamp of the notification
-  external num get timestamp;
-
-  /// Title text of the notification.
-  external String get title;
-
-  /// A vibration pattern for the device's vibration hardware to emit when the notification fires.
-  external num get vibrate;
-}
-
-/// Represents the WebPush protocol options that can be included in an admin.messaging.Message.
-@JS()
-@anonymous
-abstract class WebpushConfig {
-  /// A collection of data fields.
-  external dynamic get data;
-
-  /// Options for features provided by the FCM SDK for Web.
-  external FcmOptions get fcmOptions;
-
-  /// A collection of WebPush headers. Header values must be strings.
-  external dynamic get headers;
-
-  /// A WebPush notification payload to be included in the message.
-  external WebpushNotification get notification;
-}
-
-/// Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard).
-@JS()
-@anonymous
-abstract class WebpushFcmOptions {
-  /// The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
-  external String get link;
-}
-
-/// Options for features provided by the FCM SDK for Web.
-@JS()
-@anonymous
-abstract class FcmOptions {
-  /// The label associated with the message's analytics data.
-  external String get analyticsLabel;
-}
-
-/// Interface representing a Firebase Cloud Messaging message payload. One or both of the data and notification keys are required.
-@JS()
-@anonymous
-abstract class MessagingPayload {
-  /// The data message payload.
-  external DataMessagePayload get data;
-
-  /// The notification message payload.
-  external NotificationMessagePayload get notification;
-}
-
-/// Interface representing an FCM legacy API data message payload. Data messages let developers send up to 4KB of custom key-value pairs. The keys and values must both be strings.
-@JS()
-@anonymous
-abstract class DataMessagePayload {
-  /// Keys can be any custom string, except for the following reserved strings: 
-  /// "from" and anything starting with "google."
-  external String get key;
-
-  external dynamic get value;
-}
-
-/// Interface representing an FCM legacy API notification message payload. Notification messages let developers send up to 4KB of predefined key-value pairs. 
-@JS()
-@anonymous
-abstract class NotificationMessagePayload {
-  /// An array of notification actions representing the actions available to the user when the notification is presented.
-  external List<dynamic> get actions;
-
-  /// URL of the image used to represent the notification when there is not enough space to display the notification itself.
-  external String get badge;
-
-  /// Body text of the notification.
-  external String get body;
-
-  /// Variable string values to be used in place of the format specifiers in body_loc_key to use to localize the body text to 
-  /// the user's current localization.
-  /// 
-  /// The value should be a stringified JSON array.
-  external String get bodyLocArgs;
-
-  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
-  external String get bodyLocKey;
-
-  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is 
-  /// launched when a user clicks on the notification.
-  external String get clickAction;
-
-  /// The notification icon's color, expressed in #rrggbb format.
-  external String get color;
-
-  /// URL to the notification icon.
-  external String get icon;
-
-  /// Identifier used to replace existing notifications in the notification drawer.
-  external String get sound;
-
-  /// An identifying tag for the notification.
-  external String get tag;
-
-  /// The notification's title.
-  external String get title;
-
-  /// Variable string values to be used in place of the format specifiers in title_loc_key to use to localize the 
-  /// title text to the user's current localization.
-  /// The value should be a stringified JSON array.
-  external String get titleLocArgs;
-
-  /// The key to the title string in the app's string resources to use to localize the title text to the user's current localization.
-  external String get titleLocKey;
-}
-
-/// Interface representing the options that can be provided when sending a message via the FCM legacy APIs.
-@JS()
-@anonymous
-abstract class MessagingOptions {
-  /// String identifying a group of messages (for example, "Updates Available") that can be collapsed, so that only the last message 
-  /// gets sent when delivery can be resumed. This is used to avoid sending too many of the same messages when the device comes back online or becomes active.
-  external String get collapseKey;
-
-  /// On iOS, use this field to represent content-available in the APNs payload. When a notification or data message is sent and this is set to true, 
-  /// an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, this flag is currently not supported.
-  external bool get contentAvailable;
-
-  /// Whether or not the message should actually be sent. When set to true, allows developers to test a request without actually sending a message. 
-  /// When set to false, the message will be sent.
-  external bool get dryRun;
-
-  /// On iOS, use this field to represent mutable-content in the APNs payload. When a notification is sent and this is set to true, the content of the 
-  /// notification can be modified before it is displayed, using a Notification Service app extension
-  /// On Android and Web, this parameter will be ignored.
-  external bool get mutableContent;
-
-  /// The priority of the message. Valid values are "normal" and "high". On iOS, these correspond to APNs priorities 5 and 10.
-  external String get priority;
-
-  /// The package name of the application which the registration tokens must match in order to receive the message.
-  external String get restrictedPackageName;
-
-  /// How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. 
-  external num get timeToLive;
-}
-
-/// Represents the Android-specific options that can be included in an admin.messaging.Message.
-@JS()
-@anonymous
-abstract class AndroidConfig {
-  /// Collapse key for the message. Collapse key serves as an identifier for a group of messages that can be collapsed, so that only 
-  /// the last message gets sent when delivery can be resumed. A maximum of four different collapse keys may be active at any given time.
-  external String get collapseKey;
-
-  /// A collection of data fields to be included in the message. All values must be strings. When provided, overrides any data fields 
-  /// set on the top-level admin.messaging.Message.
-  external dynamic get data;
-
-  /// Options for features provided by the FCM SDK for Android.
-  external AndroidFcmOptions get fcmOptions;
-
-  /// Android notification to be included in the message.
-  external AndroidNotification get notification;
-
-  /// Priority of the message. Must be either normal or high.
-  external String get priority;
-
-  /// Package name of the application where the registration tokens must match in order to receive the message.
-  external String get restrictedPackageName;
-
-  /// Time-to-live duration of the message in milliseconds.
-  external num get ttl;
-}
-
-/// Represents options for features provided by the FCM SDK for Android.
-@JS()
-@anonymous
-abstract class AndroidFcmOptions {
-  /// The label associated with the message's analytics data.
-  external String get analyticsLabel;
-}
-
-/// Represents the Android-specific notification options that can be included in admin.messaging.AndroidConfig.
-@JS()
-@anonymous
-abstract class AndroidNotification {
-  /// Body of the Android notification. When provided, overrides the body set via admin.messaging.Notification
-  external String get body;
-
-  /// An array of resource keys that will be used in place of the format specifiers in bodyLocKey.
-  external List<String> get bodyLocArgs;
-
-  /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
-  external String get bodyLocKey;
-
-  /// The Android notification channel ID (new in Android O). 
-  external String get channelId;
-
-  /// Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.
-  external String get clickAction;
-
-  /// Notification icon color in #rrggbb format.
-  external String get color;
-
-  /// Icon resource for the Android notification.
-  external String get icon;
-
-  /// URL of an image to be displayed in the notification.
-  external String get imageUrl;
-
-  /// File name of the sound to be played when the device receives the notification.
-  external String get sound;
-
-  /// Notification tag. This is an identifier used to replace existing notifications
-  /// in the notification drawer. If not specified, each request creates a new notification.
-  external String get tag;
-
-  /// Title of the Android notification. When provided, overrides the title set via admin.messaging.Notification.
-  external String get title;
-
-  /// An array of resource keys that will be used in place of the format specifiers in titleLocKey.
-  external List<String> get titleLocArgs;
-
-  /// Key of the title string in the app's string resource to use to localize the title text.
-  external String get titleLocKey;
-}
-
-/// Represents the APNs-specific options that can be included in an admin.messaging.Message. 
-@JS()
-@anonymous
-abstract class ApnsConfig {
-  /// Options for features provided by the FCM SDK for iOS.
-  external ApnsFcmOptions get fcmOptions;
-
-  /// A collection of APNs headers. Header values must be strings.
-  external dynamic get headers;
-
-  /// An APNs payload to be included in the message.
-  external ApnsPayload get payload;
-}
-
-/// Represents options for features provided by the FCM SDK for iOS.
-@JS()
-@anonymous
-abstract class ApnsFcmOptions {
-  /// The label associated with the message's analytics data.
-  external String get analyticsLabel;
-
-  /// URL of an image to be displayed in the notification.
-  external String get imageUrl;
-}
-
-/// Represents options for features provided by the FCM SDK for iOS.
-@JS()
-@anonymous
-abstract class ApnsPayload {
-  /// The aps dictionary to be included in the message.
-  external Aps get aps;
-}
-
-/// Represents the aps dictionary that is part of APNs messages.
-@JS()
-@anonymous
-abstract class Aps {
-  /// Alert to be included in the message. This may be a string or an object of type admin.messaging.ApsAlert
-  external String get alert;
-
-  /// Badge to be displayed with the message. Set to 0 to remove the badge. When not specified, the badge will remain unchanged.
-  external num get badge;
-
-  /// Type of the notification.
-  external String get category;
-
-  /// Specifies whether to configure a background update notification.
-  external bool get contentAvailable;
-
-  /// Specifies whether to set the mutable-content property on the message so the clients can modify the notification via app extensions.
-  external bool get mutableContent;
-
-  /// Sound to be played with the message.
-  external String get sound;
-
-  /// An app-specific identifier for grouping notifications.
-  external String get threadId;
-}
-
-@JS()
-@anonymous
-abstract class ApsAlert {
-  external String get actionLocKey;
-  external String get body;
-  external String get launchImage;
-  external List<String> get locArgs;
-  external String get locKey;
-  external String get subtitle;
-  external List<String> get subtitleLocArgs;
-  external String get subtitleLocKey;
-  external String get title;
-  external List<String> get titleLocArgs;
-  external String get titleLocKey;
-}
-
-/// Represents a critical sound configuration that can be included in the aps dictionary of an APNs payload.
-@JS()
-@anonymous
-abstract class CriticalSound {
-  /// The critical alert flag. Set to true to enable the critical alert.
-  external bool get critical;
-
-  /// The name of a sound file in the app's main bundle or in the Library/Sounds folder of the app's container directory. 
-  /// Specify the string "default" to play the system sound.
-  external String get name;
-
-  /// The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume).
-  external num get volume;
-
-}
-/// Interface representing the server response from the sendAll() and sendMulticast() methods.
-@JS()
-@anonymous
-abstract class BatchResponse {
-  /// The number of messages that resulted in errors when sending.
-  external num get failureCount;
-
-  /// An array of responses, each corresponding to a message.
-  external List<SendResponse> get responses;
-
-  /// The number of messages that were successfully handed off for sending.
-  external num get successCount;
-}
-
-/// Interface representing the status of an individual message that was sent as part of a batch request.
-@JS()
-@anonymous
-abstract class SendResponse {
-  /// An error, if the message was not handed off to FCM successfully.
-  external FirebaseError get error;
-
-  /// A unique message ID string, if the message was handed off to FCM for delivery.
-  external String get messageId;
-
-  /// A boolean indicating if the message was successfully handed off to FCM or not. When true, the 
-  /// messageId attribute is guaranteed to be set. When false, the error attribute is guaranteed to be set.
-  external bool get success;
-}
-
-/// Interface representing the server response from the legacy sendToCondition() method.
-@JS()
-@anonymous
-abstract class MessagingConditionResponse {
-  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
-  external num get messageId;
-}
-
-/// Interface representing the server response from the sendToDeviceGroup() method.
-@JS()
-@anonymous
-abstract class MessagingDeviceGroupResponse {
-  /// An array of registration tokens that failed to receive the message.
-  external List<String> get failedRegistrationTokens;
-
-  /// The number of messages that could not be processed and resulted in an error.
-  external num get failureCount;
-
-  /// The number of messages that could not be processed and resulted in an error.
-  external num get successCount;
-}
-
-/// Interface representing the status of a message sent to an individual device via the FCM legacy APIs.
-@JS()
-@anonymous
-abstract class MessagingDeviceResult {
-  /// The canonical registration token for the client app that the message was processed and sent to. 
-  /// You should use this value as the registration token for future requests. Otherwise, 
-  /// future messages might be rejected.
-  external String get canonicalRegistrationToken;
-
-  /// The error that occurred when processing the message for the recipient.
-  external FirebaseError get error;
-
-  /// A unique ID for the successfully processed message.
-  external String get messageId;
-}
-
-/// Interface representing the server response from the legacy sendToDevice() method.
-@JS()
-@anonymous
-abstract class MessagingDevicesResponse {
-  /// The number of results that contain a canonical registration token. A canonical registration token 
-  /// is the registration token corresponding to the last registration requested by the client app. 
-  /// This is the token that you should use when sending future messages to the device.
-  /// You can access the canonical registration tokens within the results property.
-  external num get canonicalRegistrationTokenCount;
-
-  /// The number of messages that could not be processed and resulted in an error.
-  external num get failureCount;
-
-  /// The unique ID number identifying this multicast message.
-  external num get multicastId;
-
-  /// An array of [MessagingDeviceResult] objects representing the status of the processed messages. 
-  /// The objects are listed in the same order as in the request. That is, for each registration token 
-  /// in the request, its result has the same index in this array. 
-  /// If only a single registration token is provided, this array will contain a single object.
-  external List<MessagingDeviceResult> get results;
-
-  /// The number of messages that were successfully processed and sent.
-  external num get successCount;
-}
-
-/// Interface representing the server response from the legacy sendToTopic() method.
-@JS()
-@anonymous
-abstract class MessagingTopicResponse {
-  /// The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
-  external num get messageId;
-}
-
-/// Interface representing the server response from the subscribeToTopic() and 
-/// admin.messaging.Messaging#unsubscribeFromTopic unsubscribeFromTopic() methods.
-@JS()
-@anonymous
-abstract class MessagingTopicManagementResponse {
-  /// An array of errors corresponding to the provided registration token(s). The length of this array will be equal to failureCount.
-  external List<FirebaseArrayIndexError> get errors;
-
-  /// The number of registration tokens that could not be subscribed to the topic and resulted in an error.
-  external num get failureCount;
-
-  /// The number of registration tokens that were successfully subscribed to the topic.
-  external num get successCount;
+  
+  external factory MessagingTopicManagementResponse({
+    List<FirebaseArrayIndexError> errors,
+    num failureCount,
+    num successCount,
+  });
 }
 
 // admin.database ================================================================

--- a/lib/src/messaging.dart
+++ b/lib/src/messaging.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2018, Anatoly Pulyaevskiy. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:node_interop/util.dart';
+
+import 'bindings.dart' as js show Messaging;
+import 'bindings.dart'
+    show
+        FcmMessage,
+        MulticastMessage,
+        MessagingPayload,
+        MessagingOptions,
+        MessagingDevicesResponse,
+        MessagingConditionResponse,
+        MessagingDeviceGroupResponse,
+        MessagingTopicResponse,
+        MessagingTopicManagementResponse,
+        BatchResponse;
+
+export 'bindings.dart'
+    show
+        FcmMessage,
+        TopicMessage,
+        TokenMessage,
+        ConditionMessage,
+        MulticastMessage,
+        Notification,
+        WebpushNotification,
+        WebpushFcmOptions,
+        WebpushConfig,
+        FcmOptions,
+        MessagingPayload,
+        DataMessagePayload,
+        NotificationMessagePayload,
+        MessagingOptions,
+        MessagingDevicesResponse,
+        MessagingDeviceResult,
+        MessagingConditionResponse,
+        MessagingDeviceGroupResponse,
+        MessagingTopicResponse,
+        MessagingTopicManagementResponse,
+        AndroidConfig,
+        AndroidFcmOptions,
+        AndroidNotification,
+        ApnsConfig,
+        ApnsFcmOptions,
+        ApnsPayload,
+        Aps,
+        ApsAlert,
+        CriticalSound,
+        BatchResponse,
+        SendResponse;
+
+class Messaging {
+  Messaging(this.nativeInstance);
+
+  @protected
+  final js.Messaging nativeInstance;
+
+  /// Sends the given [message] via FCM.
+  /// 
+  /// Returns Promise<string> fulfilled with a unique message ID string after the 
+  /// message has been successfully handed off to the FCM service for delivery
+  Future<String> send(FcmMessage message, [bool dryRun]) {
+    if (dryRun != null)
+      return promiseToFuture(nativeInstance.send(message, dryRun));
+    else
+      return promiseToFuture(nativeInstance.send(message));
+  }
+
+  /// Sends all the [messages] in the given array via Firebase Cloud Messaging.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  Future<BatchResponse> sendAll(List<FcmMessage> messages, [bool dryRun]) {
+    if (dryRun != null)
+      return promiseToFuture(nativeInstance.sendAll(messages, dryRun));
+    else
+      return promiseToFuture(nativeInstance.sendAll(messages));
+  }
+
+  /// Sends the given multicast [message] to all the FCM registration tokens specified in it.
+  /// 
+  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  Future<BatchResponse> sendMulticast(MulticastMessage message, [bool dryRun]) {
+    if (dryRun != null)
+      return promiseToFuture(nativeInstance.sendMulticast(message, dryRun));
+    else
+      return promiseToFuture(nativeInstance.sendMulticast(message));
+  }
+
+  /// Sends an FCM message to a [condition].
+  /// 
+  /// Returns Promise<MessagingConditionResponse> fulfilled with the server's response after the message has been sent.
+  Future<MessagingConditionResponse> sendToCondition(String condition, MessagingPayload payload, [MessagingOptions options]) {
+    if (options != null)
+      return promiseToFuture(nativeInstance.sendToCondition(condition, payload, options));
+    else
+      return promiseToFuture(nativeInstance.sendToCondition(condition, payload));
+  }
+
+  /// Sends an FCM message to a single device corresponding to the provided [registrationToken].
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  Future<MessagingDevicesResponse> sendToDevice(String registrationToken, MessagingPayload payload, [MessagingOptions options]) {
+    if (options != null)
+      return promiseToFuture(nativeInstance.sendToDevice(registrationToken, payload, options));
+    else
+      return promiseToFuture(nativeInstance.sendToDevice(registrationToken, payload));
+  }
+
+  /// Sends an FCM message to a device group corresponding to the provided [notificationKey].
+  /// 
+  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  Future<MessagingDeviceGroupResponse> sendToDeviceGroup(String notificationKey, MessagingPayload payload, [MessagingOptions options]) {
+    if (options != null)
+      return promiseToFuture(nativeInstance.sendToDeviceGroup(notificationKey, payload, options));
+    else
+      return promiseToFuture(nativeInstance.sendToDeviceGroup(notificationKey, payload));
+  }
+
+  /// Sends an FCM message to a [topic].
+  /// 
+  /// Returns Promise<MessagingTopicResponse> fulfilled with the server's response after the message has been sent.
+  Future<MessagingTopicResponse> sendToTopic(String topic, MessagingPayload payload, [MessagingOptions options]) {
+    if (options != null)
+      return promiseToFuture(nativeInstance.sendToTopic(topic, payload, options));
+    else
+      return promiseToFuture(nativeInstance.sendToTopic(topic, payload));
+  }
+
+  /// Subscribes a device to an FCM [topic].
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  Future<MessagingTopicManagementResponse> subscribeToTopic(String registrationTokens, String topic) =>
+      promiseToFuture(nativeInstance.subscribeToTopic(registrationTokens, topic));
+
+  /// Unsubscribes a device from an FCM [topic].
+  /// 
+  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  Future<MessagingTopicManagementResponse> unsubscribeFromTopic(String registrationTokens, String topic) =>
+      promiseToFuture(nativeInstance.unsubscribeFromTopic(registrationTokens, topic));
+}

--- a/lib/src/messaging.dart
+++ b/lib/src/messaging.dart
@@ -62,7 +62,7 @@ class Messaging {
 
   /// Sends the given [message] via FCM.
   /// 
-  /// Returns Promise<string> fulfilled with a unique message ID string after the 
+  /// Returns Future<String> fulfilled with a unique message ID string after the 
   /// message has been successfully handed off to the FCM service for delivery
   Future<String> send(FcmMessage message, [bool dryRun]) {
     if (dryRun != null)
@@ -73,7 +73,7 @@ class Messaging {
 
   /// Sends all the [messages] in the given array via Firebase Cloud Messaging.
   /// 
-  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  /// Returns Future<BatchResponse> fulfilled with an object representing the result of the send operation.
   Future<BatchResponse> sendAll(List<FcmMessage> messages, [bool dryRun]) {
     if (dryRun != null)
       return promiseToFuture(nativeInstance.sendAll(messages, dryRun));
@@ -83,7 +83,7 @@ class Messaging {
 
   /// Sends the given multicast [message] to all the FCM registration tokens specified in it.
   /// 
-  /// Returns Promise<BatchResponse> fulfilled with an object representing the result of the send operation.
+  /// Returns Future<BatchResponse> fulfilled with an object representing the result of the send operation.
   Future<BatchResponse> sendMulticast(MulticastMessage message, [bool dryRun]) {
     if (dryRun != null)
       return promiseToFuture(nativeInstance.sendMulticast(message, dryRun));
@@ -93,7 +93,7 @@ class Messaging {
 
   /// Sends an FCM message to a [condition].
   /// 
-  /// Returns Promise<MessagingConditionResponse> fulfilled with the server's response after the message has been sent.
+  /// Returns Future<MessagingConditionResponse> fulfilled with the server's response after the message has been sent.
   Future<MessagingConditionResponse> sendToCondition(String condition, MessagingPayload payload, [MessagingOptions options]) {
     if (options != null)
       return promiseToFuture(nativeInstance.sendToCondition(condition, payload, options));
@@ -103,7 +103,7 @@ class Messaging {
 
   /// Sends an FCM message to a single device corresponding to the provided [registrationToken].
   /// 
-  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  /// Returns Future<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
   Future<MessagingDevicesResponse> sendToDevice(String registrationToken, MessagingPayload payload, [MessagingOptions options]) {
     if (options != null)
       return promiseToFuture(nativeInstance.sendToDevice(registrationToken, payload, options));
@@ -113,7 +113,7 @@ class Messaging {
 
   /// Sends an FCM message to a device group corresponding to the provided [notificationKey].
   /// 
-  /// Returns Promise<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
+  /// Returns Future<MessagingDevicesResponse> fulfilled with the server's response after the message has been sent.
   Future<MessagingDeviceGroupResponse> sendToDeviceGroup(String notificationKey, MessagingPayload payload, [MessagingOptions options]) {
     if (options != null)
       return promiseToFuture(nativeInstance.sendToDeviceGroup(notificationKey, payload, options));
@@ -123,7 +123,7 @@ class Messaging {
 
   /// Sends an FCM message to a [topic].
   /// 
-  /// Returns Promise<MessagingTopicResponse> fulfilled with the server's response after the message has been sent.
+  /// Returns Future<MessagingTopicResponse> fulfilled with the server's response after the message has been sent.
   Future<MessagingTopicResponse> sendToTopic(String topic, MessagingPayload payload, [MessagingOptions options]) {
     if (options != null)
       return promiseToFuture(nativeInstance.sendToTopic(topic, payload, options));
@@ -133,13 +133,13 @@ class Messaging {
 
   /// Subscribes a device to an FCM [topic].
   /// 
-  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  /// Returns Future<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
   Future<MessagingTopicManagementResponse> subscribeToTopic(String registrationTokens, String topic) =>
       promiseToFuture(nativeInstance.subscribeToTopic(registrationTokens, topic));
 
   /// Unsubscribes a device from an FCM [topic].
   /// 
-  /// Returns Promise<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
+  /// Returns Future<MessagingTopicManagementResponse> fulfilled with the server's response after the device has been subscribed to the topic.
   Future<MessagingTopicManagementResponse> unsubscribeFromTopic(String registrationTokens, String topic) =>
       promiseToFuture(nativeInstance.unsubscribeFromTopic(registrationTokens, topic));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   quiver_hashcode: ^2.0.0
 
 dev_dependencies:
-  test: ^1.0.0
+  test: ^1.12.0
   build_runner: ^1.7.4
   build_node_compilers: ^0.2.4
-  build_test:
+  build_test: ^0.10.12+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: firebase_admin_interop
 description: Firebase Admin SDK for Dart written as a wrapper around official Node.js SDK.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/pulyaevskiy/firebase-admin-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  js: ^0.6.1
-  node_interop: ^1.0.0-dev.11.0
-  meta: ^1.0.5
+  js: ^0.6.1+1
+  node_interop: ^1.0.3
+  meta: ^1.1.8
   quiver_hashcode: ^2.0.0
 
 dev_dependencies:
   test: ^1.0.0
-  build_runner: ^1.0.0
-  build_node_compilers: ^0.2.0
+  build_runner: ^1.7.4
+  build_node_compilers: ^0.2.4
   build_test:


### PR DESCRIPTION
Had this finished back in October, but after enough testing and requests, think it's time to push in the update..  Working quite well in my Firebase Functions Interop implementation, very useful to send notifications to users or topics from the server, pretty easy to use too.  You'll need to update the firebase_functions_interop pubspec.yaml too..